### PR TITLE
Log in as user

### DIFF
--- a/oc-admin/users.php
+++ b/oc-admin/users.php
@@ -121,6 +121,10 @@ class CAdminUsers extends AdminSecBaseModel
                         . '?page=users&action=enable&id[]=' . $aUser['pk_i_id'] . '&' . $csrf_token . '&value=ENABLE">'
                         . __('Unblock') . '</a>';
                 }
+                $actions[] = '<a class="btn btn-green float-left" href="' . osc_admin_base_url(true) . '?page=users&action=login&amp;id='
+                    . $aUser['pk_i_id'] . '&amp;' . $csrf_token . '" target="_blank">'
+                    . __('Log in') . '</a>';
+
                 $aLocale = $aUser['locale'];
                 foreach ($aLocale as $locale => $aInfo) {
                     $aUser['locale'][$locale]['s_info'] =
@@ -315,6 +319,27 @@ class CAdminUsers extends AdminSecBaseModel
                 osc_add_flash_ok_message($msg, 'admin');
                 $this->redirectTo(osc_admin_base_url(true) . '?page=users');
                 break;
+                case ('login'):         //login
+                    osc_csrf_check();
+                    $userId  = Params::getParam('id');
+                    $user = User::newInstance()->findByPrimaryKey($userId);
+
+                    if(!$user) {
+                        osc_add_flash_error_message(_m('The user doesn\'t exist'), 'admin');
+                        $this->redirectTo(osc_admin_base_url(true) . '?page=users');
+                    }
+
+                    Session::newInstance()->_set('userId', $user['pk_i_id']);
+                    Session::newInstance()->_set('userName', $user['s_name']);
+                    Session::newInstance()->_set('userEmail', $user['s_email']);
+                    $phone = ($user['s_phone_mobile']) ? $user['s_phone_mobile'] : $user['s_phone_land'];
+                    Session::newInstance()->_set('userPhone', $phone);
+
+                    osc_run_hook('after_login' , $user, osc_user_dashboard_url());
+
+                    osc_add_flash_ok_message(sprintf(_m('Logged in as %s successfully'), $user['s_name']));
+                    $this->redirectTo(osc_apply_filter('correct_login_url_redirect', osc_user_dashboard_url()));
+                    break;
             case ('delete_alerts'):
                 $iDeleted = 0;
                 $alertId  = Params::getParam('alert_id');

--- a/oc-admin/users.php
+++ b/oc-admin/users.php
@@ -319,26 +319,26 @@ class CAdminUsers extends AdminSecBaseModel
                 osc_add_flash_ok_message($msg, 'admin');
                 $this->redirectTo(osc_admin_base_url(true) . '?page=users');
                 break;
-                case ('login'):         //login
-                    osc_csrf_check();
-                    $userId  = Params::getParam('id');
-                    $user = User::newInstance()->findByPrimaryKey($userId);
+            case ('login'):         //login
+                osc_csrf_check();
+                $userId  = Params::getParam('id');
+                $user = User::newInstance()->findByPrimaryKey($userId);
 
-                    if(!$user) {
-                        osc_add_flash_error_message(_m('The user doesn\'t exist'), 'admin');
-                        $this->redirectTo(osc_admin_base_url(true) . '?page=users');
-                    }
+                if (!$user) {
+                    osc_add_flash_error_message(_m('The user doesn\'t exist'), 'admin');
+                    $this->redirectTo(osc_admin_base_url(true) . '?page=users');
+                }
 
-                    Session::newInstance()->_set('userId', $user['pk_i_id']);
-                    Session::newInstance()->_set('userName', $user['s_name']);
-                    Session::newInstance()->_set('userEmail', $user['s_email']);
-                    $phone = ($user['s_phone_mobile']) ? $user['s_phone_mobile'] : $user['s_phone_land'];
-                    Session::newInstance()->_set('userPhone', $phone);
+                Session::newInstance()->_set('userId', $user['pk_i_id']);
+                Session::newInstance()->_set('userName', $user['s_name']);
+                Session::newInstance()->_set('userEmail', $user['s_email']);
+                $phone = ($user['s_phone_mobile']) ? $user['s_phone_mobile'] : $user['s_phone_land'];
+                Session::newInstance()->_set('userPhone', $phone);
 
-                    osc_run_hook('after_login' , $user, osc_user_dashboard_url());
+                osc_run_hook('after_login', $user, osc_user_dashboard_url());
 
-                    osc_add_flash_ok_message(sprintf(_m('Logged in as %s successfully'), $user['s_name']));
-                    $this->redirectTo(osc_apply_filter('correct_login_url_redirect', osc_user_dashboard_url()));
+                osc_add_flash_ok_message(sprintf(_m('Logged in as %s successfully'), $user['s_name']));
+                $this->redirectTo(osc_apply_filter('correct_login_url_redirect', osc_user_dashboard_url()));
                     break;
             case ('delete_alerts'):
                 $iDeleted = 0;

--- a/oc-includes/osclass/classes/datatables/UsersDataTable.php
+++ b/oc-includes/osclass/classes/datatables/UsersDataTable.php
@@ -205,8 +205,11 @@ class UsersDataTable extends DataTable
                 $options[] =
                     '<a onclick="return delete_dialog(\'' . $aRow['pk_i_id'] . '\');" href="' . osc_admin_base_url(true)
                     . '?page=users&action=delete&amp;id[]=' . $aRow['pk_i_id'] . '">' . __('Delete') . '</a>';
-                $options[] = '<a href="' . osc_user_public_profile_url($aRow['pk_i_id']) . '" targe="_blank">'
+                $options[] = '<a href="' . osc_user_public_profile_url($aRow['pk_i_id']) . '" target="_blank">'
                     . __('Public profile') . '</a>';
+                $options[] = '<a href="' . osc_admin_base_url(true) . '?page=users&action=login&amp;id='
+                    . $aRow['pk_i_id'] . '&amp;' . $csrf_token_url . '" target="_blank">'
+                    . __('Log in') . '</a>';
 
                 if ($aRow['b_active'] == 1) {
                     $options_more[] = '<a href="' . osc_admin_base_url(true) . '?page=users&action=deactivate&amp;id[]='


### PR DESCRIPTION
Log in as a user on user datatable and user edit page.
Similar login as on old Admin Tools - Login plugin.

Unlike that old plugin, the buttons are on backend instead of the frontend. The frontend is up to theme devs.
I also added after_login hook and redirect URL filter.

https://github.com/mindstellar/Osclass/issues/211