### PR TITLE
Item & user datatable filters

### DIFF
--- a/oc-includes/osclass/classes/datatables/ItemsDataTable.php
+++ b/oc-includes/osclass/classes/datatables/ItemsDataTable.php
@@ -227,9 +227,7 @@ class ItemsDataTable extends DataTable
             $sort = $arraySortColumns[$sort];
         }
         // only some fields can be ordered
-
-        $order_by = osc_apply_filter('manage_item_search_order_by', array('column_name' => $sort, 'type' => $direction));
-        $this->mSearch->order($order_by['column_name'], $order_by['type']);
+        $this->mSearch->order($sort, $direction);
     }
 
     /**

--- a/oc-includes/osclass/classes/datatables/ItemsDataTable.php
+++ b/oc-includes/osclass/classes/datatables/ItemsDataTable.php
@@ -57,9 +57,9 @@ class ItemsDataTable extends DataTable
         $this->addTableHeader();
         $this->mSearch = new Search(true);
         $this->getDBParams($params);
-        // add more conditions here
+
         osc_run_hook('manage_item_search_conditions', $this->mSearch);
-        // do Search
+
         $this->processData(Item::newInstance()->extendCategoryName($this->mSearch->doSearch()));
         $this->totalFiltered = $this->mSearch->countAll();
         $this->total         = $this->mSearch->count();
@@ -227,7 +227,9 @@ class ItemsDataTable extends DataTable
             $sort = $arraySortColumns[$sort];
         }
         // only some fields can be ordered
-        $this->mSearch->order($sort, $direction);
+
+        $order_by = osc_apply_filter('manage_item_search_order_by', array('column_name' => $sort, 'type' => $direction));
+        $this->mSearch->order($order_by['column_name'], $order_by['type']);
     }
 
     /**
@@ -698,7 +700,7 @@ class ItemsDataTable extends DataTable
      */
     public function withFilters()
     {
-        return $this->withFilters;
+        return osc_apply_filter('manage_item_search_with_filters', $this->withFilters);
     }
 
     /**

--- a/oc-includes/osclass/classes/datatables/UsersDataTable.php
+++ b/oc-includes/osclass/classes/datatables/UsersDataTable.php
@@ -40,10 +40,10 @@ class UsersDataTable extends DataTable
 
     private $withUserId;
     private $search;
-    private $order_by;
-    private $conditions;
-    private $withFilters = false;
     private $column_names;
+    public $order_by;
+    public $conditions;
+    public $withFilters = false;
 
     public function __construct()
     {
@@ -64,8 +64,8 @@ class UsersDataTable extends DataTable
         $this->addTableHeader();
         $this->getDBParams($params);
 
-        osc_run_hook('manage_user_search_conditions', $this->conditions);
-        $this->order_by = osc_apply_filter('manage_user_search_order_by', $this->order_by);
+        $dummy = &$this;
+        osc_run_hook('manage_user_search_conditions', $dummy);
 
         $list_users = User::newInstance()->search(
             $this->start,

--- a/oc-includes/osclass/classes/datatables/UsersDataTable.php
+++ b/oc-includes/osclass/classes/datatables/UsersDataTable.php
@@ -64,6 +64,9 @@ class UsersDataTable extends DataTable
         $this->addTableHeader();
         $this->getDBParams($params);
 
+        osc_run_hook('manage_user_search_conditions', $this->conditions);
+        $this->order_by = osc_apply_filter('manage_user_search_order_by', $this->order_by);
+
         $list_users = User::newInstance()->search(
             $this->start,
             $this->limit,
@@ -336,7 +339,7 @@ class UsersDataTable extends DataTable
      */
     public function withFilters()
     {
-        return $this->withFilters;
+        return osc_apply_filter('manage_user_search_with_filters', $this->withFilters);
     }
 
     /**


### PR DESCRIPTION
`manage_item_search_order_by` & `manage_user_search_order_by` - for changing default order of results in the tables.

`manage_user_search_conditions` - similar to existing filter for item table.

`manage_item_search_with_filters` & `manage_user_search_with_filters` - if any filters are added with appropriate hooks, this filters should be utilized as well so the "Reset filters" button shows